### PR TITLE
Use ppx_tools_versioned instead of ppxlib.

### DIFF
--- a/ppx/dune
+++ b/ppx/dune
@@ -5,6 +5,6 @@
  (modules ppx_pgsql)
  (kind ppx_rewriter)
  (flags (:standard -safe-string))
- (libraries pgocaml ppxlib)
+ (libraries pgocaml ocaml-migrate-parsetree)
  (ppx_runtime_libraries pgocaml ppx_pgsql.runtime)
- (preprocess (pps ppxlib.metaquot)))
+ (preprocess (pps ppx_tools_versioned.metaquot_408)))

--- a/ppx_pgsql.opam
+++ b/ppx_pgsql.opam
@@ -10,10 +10,10 @@ build: [
 ]
 depends: [
     "pgocaml"
-    "ppxlib"
     "dune"                    {build & >= "1.0"}
     "ocamlfind"               {build}
     "ocaml-migrate-parsetree" {>= "0.4"}
+    "ppx_tools_versioned"
 ]
 tags: ["postgresql" "pgocaml" "ppx"]
 available: [


### PR DESCRIPTION
Hi,

This pull request fixes the build errors encountered with recent versions of OCaml and compiler-libs. I could then successfully install the ppx via opam with all versions of OCaml down to 4.06 .

This is simply a cleanup of the work found on @baransu 's fork.

Cheers,